### PR TITLE
Feat/Health Readyz Endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+temp

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ tunely help
 tunely relay --config /etc/tunely/relay.yaml
 tunely agent --relay ws://127.0.0.1:8080/ws --tunnel-id demo --token xxx --local http://127.0.0.1:3000
 curl -v http://127.0.0.1:8080/t/demo/
+curl -s http://127.0.0.1:8080/healthz
+curl -s http://127.0.0.1:8080/readyz
 ```
 
 Relay 설정 파일:

--- a/crates/relay-server/src/health.rs
+++ b/crates/relay-server/src/health.rs
@@ -1,0 +1,47 @@
+use axum::Json;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct HealthPayload {
+    pub status: &'static str,
+    pub service: &'static str,
+    pub version: &'static str,
+}
+
+pub async fn healthz() -> Json<HealthPayload> {
+    Json(HealthPayload {
+        status: "ok",
+        service: "relay-server",
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}
+
+pub async fn readyz() -> Json<HealthPayload> {
+    Json(HealthPayload {
+        status: "ready",
+        service: "relay-server",
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{healthz, readyz};
+    use axum::Json;
+
+    #[tokio::test]
+    async fn healthz_returns_ok_payload() {
+        let Json(payload) = healthz().await;
+        assert_eq!(payload.status, "ok");
+        assert_eq!(payload.service, "relay-server");
+        assert!(!payload.version.is_empty());
+    }
+
+    #[tokio::test]
+    async fn readyz_returns_ready_payload() {
+        let Json(payload) = readyz().await;
+        assert_eq!(payload.status, "ready");
+        assert_eq!(payload.service, "relay-server");
+        assert!(!payload.version.is_empty());
+    }
+}

--- a/crates/relay-server/src/main.rs
+++ b/crates/relay-server/src/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod health;
 mod http_ingress;
 mod ingress;
 mod state;
@@ -27,6 +28,8 @@ async fn main() -> anyhow::Result<()> {
     let state = AppState::new(config.auth_tokens.clone(), config.request_timeout_secs);
 
     let app = Router::new()
+        .route("/healthz", get(health::healthz))
+        .route("/readyz", get(health::readyz))
         .route("/ws", get(ws_session::ws_handler))
         .route("/t/:tunnel_id", any(ingress::ingress_root))
         .route("/t/:tunnel_id/", any(ingress::ingress_root))

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -123,6 +123,13 @@ cargo run -p echo-server
 cargo run -p relay-server -- --listen 0.0.0.0:8080 --auth-token "test-token"
 ```
 
+헬스 체크:
+
+```bash
+curl -s http://127.0.0.1:8080/healthz
+curl -s http://127.0.0.1:8080/readyz
+```
+
 **터미널 3 - Agent:**
 
 ```bash


### PR DESCRIPTION
## 변경 요약
- `relay-server`에 상태 확인 엔드포인트 2개를 추가했습니다.
  - `GET /healthz`
  - `GET /readyz`
- 응답은 JSON으로 고정했습니다.
  - `status`: `ok` / `ready`
  - `service`: `relay-server`
  - `version`: `CARGO_PKG_VERSION`
- 범위에서 제외한 항목:
  - `/metrics` 미구현 (요청 사항 반영)
- 문서 보강:
  - `README.md` 빠른 시작에 health/ready 체크 예시 추가
  - `docs/local-dev.md`에 health check 예시 추가

## 관련 이슈
- Closes #8 

## 테스트 체크리스트
- [x] 로컬에서 변경 사항을 실행/확인했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 필요한 테스트(단위/통합/수동)를 추가하거나 업데이트했습니다.
- [x] 테스트 결과를 확인했습니다.

실행 명령:

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```

## 리스크/주의사항
- 배포 또는 운영 영향:
  - 신규 공개 엔드포인트(`/healthz`, `/readyz`)가 추가됩니다.
- 롤백 방법:
  - 해당 라우트/핸들러 커밋 revert.
- 추가로 확인이 필요한 항목:
  - 운영 환경에서 헬스체크 경로 접근 제어가 필요한지(프록시/LB 정책).
